### PR TITLE
Change thumb for world layer and enter

### DIFF
--- a/config/imprint.keymap
+++ b/config/imprint.keymap
@@ -2496,7 +2496,7 @@
             tapping-term-ms = <140>; // <THUMB_HOLDING_TIME>; -> 190ms
             quick-tap-ms = <THUMB_REPEAT_DECAY>; // enable repeat
             #binding-cells = <2>;
-            bindings = <&mo>, <&kp>>>;
+            bindings = <&mo>, <&kp>;
         };
 
         //


### PR DESCRIPTION
Améliorer le passage au World Layer sur la touche entré.

## Comportement actuelle : 

flavor : "balanced"
tapping-term-ms :	190 ms
quick-tap-ms : 290 ms

```
Si tu tapes rapidement (moins de 190 ms), c’est un tap (ex : espace).
Si tu maintiens plus de 190 ms, c’est un hold (ex : accès à un layer).
Si tu tapes puis maintiens dans les 290 ms, tu déclenches la répétition.
N’hésite pas si tu veux le détail pour d’autres comportements !
```

## Objectif : 

Trouvé un meilleur timing !