### PR TITLE
Ajout key layer syst left hand

### DIFF
--- a/config/imprint.keymap
+++ b/config/imprint.keymap
@@ -7005,7 +7005,7 @@
 
         layer_QWERTY {
             bindings = <
-&                 &none                         &none                         &none                         &none                           &none                                    &none       &none                          &none                           &none                          &none                          &none
+&none             &none                         &none                         &none                         &none                           &none                                    &none       &none                          &none                           &none                          &none                          &none
 &none             &kp N1                        &kp N2                        &world_e_acute                &kp SQT                         &kp N5                                   &kp N6      &kp N7                         &kp N8                          &kp N9                         &kp N0                         &none
 &none             &kp Q                         &kp W                         &kp E                         &kp R                           &kp T                                    &kp Y       &kp U                          &kp I                           &kp O                          &kp SEMI                       &none
 &mo LAYER_System  &LeftPinky (A, LAYER_QWERTY)  &LeftRingy (S, LAYER_QWERTY)  &LeftMiddy (D, LAYER_QWERTY)  &LeftIndex (F, LAYER_QWERTY)    &kp G                                    &kp H       &RightIndex (J, LAYER_QWERTY)  &RightMiddy (K, LAYER_QWERTY)   &RightRingy (L, LAYER_QWERTY)  &RightPinky (P, LAYER_QWERTY)  &none


### PR DESCRIPTION
L'objectif est de facilité le changement de bluetooth (changemenet de pc) du clavier à une main en ajouter la touche layer `System` sur la main gauche pour le faire d'une main.