### PR TITLE
Add space on world layer in left hand to chor special a and space

### DIFF
--- a/config/imprint.keymap
+++ b/config/imprint.keymap
@@ -7211,7 +7211,7 @@
 &none  &none                 &none  &none                         &none  &none            &none      &none                &none          &none           &none      &none
 &none  &none                 &none  &none                         &none  &none            &none      &none                &none          &none           &none      &none
 &none  &none                 &none  &world_e_base_perso           &none  &none            &none      &world_u_base_perso  &world_i_base  &world_o_base   &none      &none
-&none  &world_a_base_perso   &none  &none                         &none  &none            &kp SPACE  &sk LSHFT            &sk LCTRL      &sk RCTRL       &sk RSHFT  &none
+&none  &world_a_base_perso   &none  &kp SPACE                     &none  &none            &kp SPACE  &sk LSHFT            &sk LCTRL      &sk RCTRL       &sk RSHFT  &none
 &none  &world_currency_base  &none  &world_consonants_base_perso  &none  &none            &none      &none                &sk LALT       &sk RALT        &none      &none
 &none  &none                 &none  &none                         &none                              &none                &none          &none           &none      &none
                                                                   &trans &none   &none    &none      &none                &none


### PR DESCRIPTION
L'objectif est de facilité d'écrire `à ` qui demande de jouer avec le pouce droit sur le thumb cluster. Si l'on ajouter `space` sur la main gauche, l'on peut faire un chor assez forte en appuyant sur `a` puis `d` pour faire `à ` tout en tenant le pouce droit sur `enter` pour l'activation du layer `world`.