### PR TITLE
Change space world layout to be more easy

### DIFF
--- a/config/imprint.keymap
+++ b/config/imprint.keymap
@@ -7208,14 +7208,14 @@
 
         layer_World {
             bindings = <
-&none  &none                 &none  &none                         &none  &none            &none      &none                &none          &none           &none      &none
-&none  &none                 &none  &none                         &none  &none            &none      &none                &none          &none           &none      &none
-&none  &none                 &none  &world_e_base_perso           &none  &none            &none      &world_u_base_perso  &world_i_base  &world_o_base   &none      &none
-&none  &world_a_base_perso   &none  &kp SPACE                     &none  &none            &kp SPACE  &sk LSHFT            &sk LCTRL      &sk RCTRL       &sk RSHFT  &none
-&none  &world_currency_base  &none  &world_consonants_base_perso  &none  &none            &none      &none                &sk LALT       &sk RALT        &none      &none
+&none  &none                 &none  &none                         &none      &none            &none      &none                &none          &none           &none      &none
+&none  &none                 &none  &none                         &none      &none            &none      &none                &none          &none           &none      &none
+&none  &none                 &none  &world_e_base_perso           &none      &none            &none      &world_u_base_perso  &world_i_base  &world_o_base   &none      &none
+&none  &world_a_base_perso   &none  &none                         &kp SPACE  &none            &kp SPACE  &sk LSHFT            &sk LCTRL      &sk RCTRL       &sk RSHFT  &none
+&none  &world_currency_base  &none  &world_consonants_base_perso  &none      &none            &none      &none                &sk LALT       &sk RALT        &none      &none
 &none  &none                 &none  &none                         &none                              &none                &none          &none           &none      &none
-                                                                  &trans &none   &none    &none      &none                &none
-                                                                  &trans &trans  &none    &none      &none                &none
+                                                                  &trans     &none   &none    &none      &none                &none
+                                                                  &trans     &trans  &none    &none      &none                &none
             >;
         };
     };


### PR DESCRIPTION
Modifie la position de `space` sur le layer `world` afin de passer de `d` -> `f` plus simple.

Précédente PR #15 