### PR TITLE
delete / space as symbol layer for right hand on World layer

### DIFF
--- a/config/imprint.keymap
+++ b/config/imprint.keymap
@@ -7211,8 +7211,8 @@
 &none  &none                 &none  &none                         &none      &none            &none      &none                &none          &none           &none      &none
 &none  &none                 &none  &none                         &none      &none            &none      &none                &none          &none           &none      &none
 &none  &none                 &none  &world_e_base_perso           &none      &none            &none      &world_u_base_perso  &world_i_base  &world_o_base   &none      &none
-&none  &world_a_base_perso   &none  &none                         &kp SPACE  &none            &kp SPACE  &sk LSHFT            &sk LCTRL      &sk RCTRL       &sk RSHFT  &none
-&none  &world_currency_base  &none  &world_consonants_base_perso  &none      &none            &none      &none                &sk LALT       &sk RALT        &none      &none
+&none  &world_a_base_perso   &none  &none                         &kp SPACE  &none            &kp BSPC   &kp SPACE            &sk LCTRL      &sk RCTRL       &sk RSHFT  &none
+&none  &world_currency_base  &none  &world_consonants_base_perso  &none      &none            &none      &sk LSHFT            &sk LALT       &sk RALT        &none      &none
 &none  &none                 &none  &none                         &none                              &none                &none          &none           &none      &none
                                                                   &trans     &none   &none    &none      &none                &none
                                                                   &trans     &trans  &none    &none      &none                &none


### PR DESCRIPTION
On reprend la même philosophie de placement pour `delete` & `space` sur le layer `Symbol` (sur `h` & `j`) pour le layer `World`. On descend la touche `shift` de `j` vers `m` afin de toujours pouvoir réaliser simplement ce type de charactère `À`.