### PR TITLE
Tune combo special key timeout-ms

### DIFF
--- a/config/imprint.keymap
+++ b/config/imprint.keymap
@@ -2546,7 +2546,7 @@
         #define COMBO_FIRING_DECAY_SPECIAL_CARAC 50
         #endif
         #ifndef COMBO_FIRING_DECAY_SPECIAL_CARAC_E_GRAVE
-        #define COMBO_FIRING_DECAY_SPECIAL_CARAC_E_GRAVE 40
+        #define COMBO_FIRING_DECAY_SPECIAL_CARAC_E_GRAVE 36
         #endif
         
         #ifdef _A_TAB


### PR DESCRIPTION
Tuning combo for `è`, `à` and `ç` in qwerty layout.